### PR TITLE
Fix Twig loading exception on first page load

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -12,7 +12,7 @@ parameters:
 services:
     ezdesign.template_name_resolver:
         class: EzSystems\EzPlatformDesignEngine\Templating\ThemeTemplateNameResolver
-        arguments: ["$design$"]
+        arguments: ["@ezpublish.config.resolver"]
 
     ezdesign.template_path_registry:
         class: EzSystems\EzPlatformDesignEngine\Templating\TemplatePathRegistry
@@ -53,4 +53,4 @@ services:
             - "@ezdesign.asset_path_resolver"
             - "@assets._default_package"
         calls:
-            - [setCurrentDesign, ["$design$"]]
+            - [setConfigResolver, ["@ezpublish.config.resolver"]]

--- a/lib/Asset/ThemePackage.php
+++ b/lib/Asset/ThemePackage.php
@@ -35,11 +35,11 @@ class ThemePackage implements PackageInterface, DesignAwareInterface
 
     public function getUrl($path)
     {
-        return $this->innerPackage->getUrl($this->pathResolver->resolveAssetPath($path, $this->currentDesign));
+        return $this->innerPackage->getUrl($this->pathResolver->resolveAssetPath($path, $this->getCurrentDesign()));
     }
 
     public function getVersion($path)
     {
-        return $this->innerPackage->getVersion($this->pathResolver->resolveAssetPath($path, $this->currentDesign));
+        return $this->innerPackage->getVersion($this->pathResolver->resolveAssetPath($path, $this->getCurrentDesign()));
     }
 }

--- a/lib/DesignAwareInterface.php
+++ b/lib/DesignAwareInterface.php
@@ -12,9 +12,9 @@ namespace EzSystems\EzPlatformDesignEngine;
 interface DesignAwareInterface
 {
     /**
-     * Injects current design.
+     * Returns current design.
      *
-     * @param string $currentDesign
+     * @return string
      */
-    public function setCurrentDesign($currentDesign);
+    public function getCurrentDesign();
 }

--- a/lib/DesignAwareTrait.php
+++ b/lib/DesignAwareTrait.php
@@ -9,20 +9,27 @@
 
 namespace EzSystems\EzPlatformDesignEngine;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
 trait DesignAwareTrait
 {
     /**
-     * @var string
+     * @var ConfigResolverInterface
      */
-    protected $currentDesign;
+    private $configResolver;
+
+    public function setConfigResolver(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
 
     /**
-     * Injects the current design.
+     * Returns the current design.
      *
-     * @param string $currentDesign
+     * @return string
      */
-    public function setCurrentDesign($currentDesign)
+    public function getCurrentDesign()
     {
-        $this->currentDesign = $currentDesign;
+        return $this->configResolver->getParameter('design');
     }
 }

--- a/lib/Templating/ThemeTemplateNameResolver.php
+++ b/lib/Templating/ThemeTemplateNameResolver.php
@@ -9,12 +9,14 @@
 
 namespace EzSystems\EzPlatformDesignEngine\Templating;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
 class ThemeTemplateNameResolver implements TemplateNameResolverInterface
 {
     /**
-     * @var string Name of the current design, in the current context (e.g. SiteAccess)
+     * @var ConfigResolverInterface
      */
-    private $currentDesign;
+    private $configResolver;
 
     /**
      * Collection of already resolved template names.
@@ -23,9 +25,19 @@ class ThemeTemplateNameResolver implements TemplateNameResolverInterface
      */
     private $resolvedTemplateNames = [];
 
-    public function __construct($currentDesign)
+    public function __construct(ConfigResolverInterface $configResolver)
     {
-        $this->currentDesign = $currentDesign;
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * Returns the name of the current design, in the current context (i.e. SiteAccess).
+     *
+     * @return string
+     */
+    private function getCurrentDesign()
+    {
+        return $this->configResolver->getParameter('design');
     }
 
     public function resolveTemplateName($name)
@@ -36,11 +48,11 @@ class ThemeTemplateNameResolver implements TemplateNameResolverInterface
             return $this->resolvedTemplateNames[$name];
         }
 
-        return $this->resolvedTemplateNames[$name] = str_replace('@' . self::EZ_DESIGN_NAMESPACE, '@' . $this->currentDesign, $name);
+        return $this->resolvedTemplateNames[$name] = str_replace('@' . self::EZ_DESIGN_NAMESPACE, '@' . $this->getCurrentDesign(), $name);
     }
 
     public function isTemplateDesignNamespaced($name)
     {
-        return (strpos($name, '@' . self::EZ_DESIGN_NAMESPACE) !== false) || (strpos($name, '@' . $this->currentDesign) !== false);
+        return (strpos($name, '@' . self::EZ_DESIGN_NAMESPACE) !== false) || (strpos($name, '@' . $this->getCurrentDesign()) !== false);
     }
 }

--- a/tests/lib/Asset/ThemePackageTest.php
+++ b/tests/lib/Asset/ThemePackageTest.php
@@ -9,6 +9,7 @@
 
 namespace EzSystems\EzPlatformDesignEngine\Tests\Asset;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformDesignEngine\Asset\AssetPathResolverInterface;
 use EzSystems\EzPlatformDesignEngine\Asset\ThemePackage;
 use PHPUnit_Framework_TestCase;
@@ -26,12 +27,18 @@ class ThemePackageTest extends PHPUnit_Framework_TestCase
      */
     private $innerPackage;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->assetPathResolver = $this->createMock(AssetPathResolverInterface::class);
         $this->innerPackage = $this->createMock(PackageInterface::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
     }
 
     public function testGetUrl()
@@ -50,9 +57,13 @@ class ThemePackageTest extends PHPUnit_Framework_TestCase
             ->method('getUrl')
             ->with($fullAssetPath)
             ->willReturn("/$fullAssetPath");
+        $this->configResolver
+            ->method('getParameter')
+            ->with('design')
+            ->willReturn($currentDesign);
 
         $package = new ThemePackage($this->assetPathResolver, $this->innerPackage);
-        $package->setCurrentDesign($currentDesign);
+        $package->setConfigResolver($this->configResolver);
         self::assertSame("/$fullAssetPath", $package->getUrl($assetPath));
     }
 
@@ -73,9 +84,13 @@ class ThemePackageTest extends PHPUnit_Framework_TestCase
             ->method('getVersion')
             ->with($fullAssetPath)
             ->willReturn($version);
+        $this->configResolver
+            ->method('getParameter')
+            ->with('design')
+            ->willReturn($currentDesign);
 
         $package = new ThemePackage($this->assetPathResolver, $this->innerPackage);
-        $package->setCurrentDesign($currentDesign);
+        $package->setConfigResolver($this->configResolver);
         self::assertSame($version, $package->getVersion($assetPath));
     }
 }

--- a/tests/lib/Templating/ThemeTemplateNameResolverTest.php
+++ b/tests/lib/Templating/ThemeTemplateNameResolverTest.php
@@ -9,11 +9,24 @@
 
 namespace EzSystems\EzPlatformDesignEngine\Tests\Templating;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformDesignEngine\Templating\ThemeTemplateNameResolver;
 use PHPUnit_Framework_TestCase;
 
 class ThemeTemplateNameResolverTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ConfigResolverInterface
+     */
+    private $configResolver;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+    }
+
     public function templateNameProvider()
     {
         return [
@@ -28,7 +41,11 @@ class ThemeTemplateNameResolverTest extends PHPUnit_Framework_TestCase
      */
     public function testResolveTemplateName($currentDesign, $templateName, $expectedTemplateName)
     {
-        $resolver = new ThemeTemplateNameResolver($currentDesign);
+        $this->configResolver
+            ->method('getParameter')
+            ->with('design')
+            ->willReturn($currentDesign);
+        $resolver = new ThemeTemplateNameResolver($this->configResolver);
         self::assertSame($expectedTemplateName, $resolver->resolveTemplateName($templateName));
     }
 
@@ -47,7 +64,11 @@ class ThemeTemplateNameResolverTest extends PHPUnit_Framework_TestCase
      */
     public function testIsTemplateDesignNamespaced($currentDesign, $templateName, $expected)
     {
-        $resolver = new ThemeTemplateNameResolver($currentDesign);
+        $this->configResolver
+            ->method('getParameter')
+            ->with('design')
+            ->willReturn($currentDesign);
+        $resolver = new ThemeTemplateNameResolver($this->configResolver);
         self::assertSame($expected, $resolver->isTemplateDesignNamespaced($templateName));
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27510
> https://github.com/ezsystems/ezpublish-kernel/pull/2028

This patch fixes the Twig exception saying it can't load a given template using `@standard` namespace.

This is due to [EZP-27510](https://jira.ez.no/browse/EZP-27510) as ConfigResolver's default scope is not up-to-date after cache warmup process.
This fix requires https://github.com/ezsystems/ezpublish-kernel/pull/2028 to be merged.

Note that I replaced `$design$` parameter injection by the whole ConfigResolver. This is to ensure that we'll have the correct design when we need it.