### PR TITLE
Fix check for wrong definition in TwigThemePass

### DIFF
--- a/bundle/DependencyInjection/Compiler/TwigThemePass.php
+++ b/bundle/DependencyInjection/Compiler/TwigThemePass.php
@@ -26,7 +26,7 @@ class TwigThemePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!($container->hasParameter('kernel.bundles') && $container->hasDefinition('twig.loader.filesystem'))) {
+        if (!($container->hasParameter('kernel.bundles') && $container->hasDefinition('ezdesign.twig_theme_loader'))) {
             return;
         }
 


### PR DESCRIPTION
`TwigThemePass` is added at the `PassConfig::TYPE_OPTIMIZE` step, so `twig.loader.filesystem` 
 may have already been removed (private service, may be inlined so service definition may not exist any more).

Also fixed in [`lolautruche/ez-core-extra-bundle`](https://github.com/lolautruche/EzCoreExtraBundle)