### PR TITLE
Fix compatibility with Symfony 3.4 in TwigDataCollector

### DIFF
--- a/bundle/DataCollector/TwigDataCollector.php
+++ b/bundle/DataCollector/TwigDataCollector.php
@@ -22,9 +22,9 @@ class TwigDataCollector extends BaseCollector implements LateDataCollectorInterf
      */
     private $templatePathRegistry;
 
-    public function __construct(\Twig_Profiler_Profile $profile, TemplatePathRegistryInterface $templatePathRegistry)
+    public function __construct(\Twig_Profiler_Profile $profile, \Twig_Environment $environment, TemplatePathRegistryInterface $templatePathRegistry)
     {
-        parent::__construct($profile);
+        parent::__construct($profile, $environment);
         $this->templatePathRegistry = $templatePathRegistry;
     }
 

--- a/bundle/DependencyInjection/Compiler/TwigThemePass.php
+++ b/bundle/DependencyInjection/Compiler/TwigThemePass.php
@@ -99,8 +99,17 @@ class TwigThemePass implements CompilerPassInterface
         );
         $container->setParameter('ezdesign.templates_path_map', $themesPathMap);
 
-        $container->findDefinition('data_collector.twig')
-            ->setClass(TwigDataCollector::class)
-            ->addArgument(new Reference('ezdesign.template_path_registry'));
+        $twigDataCollector = $container->findDefinition('data_collector.twig');
+        $twigDataCollector->setClass(TwigDataCollector::class);
+
+        if (count($twigDataCollector->getArguments()) === 1) {
+            // In versions of Symfony prior to 3.4, "data_collector.twig" had only one
+            // argument, we're adding "twig" service to satisfy constructor overriden
+            // in EzSystems\EzPlatformDesignEngineBundle\DataCollector\TwigDataCollector
+            // which is based on Symfony 3.4 version of base TwigDataCollector
+            $twigDataCollector->addArgument(new Reference('twig'));
+        }
+
+        $twigDataCollector->addArgument(new Reference('ezdesign.template_path_registry'));
     }
 }


### PR DESCRIPTION
Base TwigDataCollector added a second, required parameter (`twig` service) in https://github.com/symfony/symfony/pull/24236 so this tries to support both the old and new variant of the collector.