### PR TITLE
EZP-29237: Dropped app/Resources/views as a theme override directory

### DIFF
--- a/bundle/DependencyInjection/Compiler/TwigThemePass.php
+++ b/bundle/DependencyInjection/Compiler/TwigThemePass.php
@@ -35,10 +35,7 @@ class TwigThemePass implements CompilerPassInterface
             (new Filesystem())->mkdir($globalViewsDir);
         }
         $themesPathMap = [
-            '_override' => array_merge(
-                [$globalViewsDir],
-                $container->getParameter('ezdesign.templates_override_paths')
-            ),
+            '_override' => $container->getParameter('ezdesign.templates_override_paths'),
         ];
         $finder = new Finder();
         // Look for themes in bundles.


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-29237 for the detailed description and reasoning.

For now going with softer change - not completely removing `_override` but removing `app/Resources/views` from the list.