### PR TITLE
Set v2.0 of the eZ Design Engine and aligned the doc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     },
     "conflict": {

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -36,9 +36,18 @@ ezpublish:
 ## Fallback order
 
 The default fallback order is:
-- Application view directory: `app/Resources/views/`
 - Application theme directory: `app/Resources/views/themes/<theme_name>/`
 - Bundle theme directory: `src/<bundle_directory>/Resources/views/themes/<theme_name>/`
+
+Prior to version 2.0 of this package, `app/Resources/views` was the top-level global override directory.
+This behavior is not recommended as it could affect both core features and third party bundles 
+which already use `@ezdesign`. However, if still needed, it can be achieved by the following configuration:
+
+```yaml
+ezdesign:
+    templates_override_paths:
+        - '%kernel.root_dir%/app/Resources/views'
+```
 
 > Bundle fallback order is the instantiation order in `AppKernel`.
 
@@ -64,7 +73,7 @@ ezdesign:
 
 ### Additional override paths
 
-It is possible to add additional global override directories, similar to `app/Resources/views/`.
+It is possible to add additional global override directories.
 
 ```yaml
 ezdesign:
@@ -72,8 +81,6 @@ ezdesign:
         - "%kernel.root_dir%/another_override_directory"
         - "/some/other/directory"
 ```
-
-> `app/Resources/views/` will **always** be the top level override directory.
 
 ## PHPStorm support
 

--- a/doc/upgrade/UPGRADE-2.0.md
+++ b/doc/upgrade/UPGRADE-2.0.md
@@ -1,0 +1,17 @@
+# Upgrading eZ Design Engine to v2.0
+
+## Backward incompatible changes
+
+### Global override directory
+
+The `app/Resources/views` project directory is no longer a global override directory for all 
+Designs and Themes. Using it is not recommended as it can lead to accidental overriding of core or 
+third party bundle templates which also use `@ezdesign` and share the same name.
+
+However, if still needed, it can be achieved by the following configuration:
+
+```yaml
+ezdesign:
+    templates_override_paths:
+        - '%kernel.root_dir%/app/Resources/views'
+```


### PR DESCRIPTION
This PR:
- [x] Sets Composer `branch-alias->dev-master` as `2.0.x-dev`
- [x] Changes doc to take into the account change from #17 dropping `app/Resources/views` as global override path.
- [x] Adds related BC/UPGRADE notes.

Note that there is already `1.2` branch available, keeping previous behavior.