### PR TITLE
Aligned Travis, CS, and PHPUnit setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 .php_cs.cache
+/.phpunit.result.cache

--- a/.php_cs
+++ b/.php_cs
@@ -18,6 +18,7 @@ return PhpCsFixer\Config::create()
         'space_after_semicolon' => false,
         'yoda_style' => false,
         'no_break_comment' => false,
+        'phpdoc_types_order' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ cache:
 
 matrix:
     include:
-        - php: 5.6
-        - php: 7.0
-        - php: 7.1
+        - php: 7.3
           env: FIX_CS=true
 
 branches:

--- a/bundle/DependencyInjection/Compiler/AssetThemePass.php
+++ b/bundle/DependencyInjection/Compiler/AssetThemePass.php
@@ -31,7 +31,7 @@ class AssetThemePass implements CompilerPassInterface
         // Look for assets themes in bundles.
         foreach ($container->getParameter('kernel.bundles') as $bundleName => $bundleClass) {
             $bundleReflection = new \ReflectionClass($bundleClass);
-            $bundleViewsDir = dirname($bundleReflection->getFileName()) . '/Resources/public';
+            $bundleViewsDir = \dirname($bundleReflection->getFileName()) . '/Resources/public';
             $themeDir = $bundleViewsDir . '/themes';
             if (!is_dir($themeDir)) {
                 continue;

--- a/bundle/DependencyInjection/Compiler/TwigThemePass.php
+++ b/bundle/DependencyInjection/Compiler/TwigThemePass.php
@@ -41,7 +41,7 @@ class TwigThemePass implements CompilerPassInterface
         // Look for themes in bundles.
         foreach ($container->getParameter('kernel.bundles') as $bundleName => $bundleClass) {
             $bundleReflection = new ReflectionClass($bundleClass);
-            $bundleViewsDir = dirname($bundleReflection->getFileName()) . '/Resources/views';
+            $bundleViewsDir = \dirname($bundleReflection->getFileName()) . '/Resources/views';
             $themeDir = $bundleViewsDir . '/themes';
             if (!is_dir($themeDir)) {
                 continue;
@@ -99,7 +99,7 @@ class TwigThemePass implements CompilerPassInterface
         $twigDataCollector = $container->findDefinition('data_collector.twig');
         $twigDataCollector->setClass(TwigDataCollector::class);
 
-        if (count($twigDataCollector->getArguments()) === 1) {
+        if (\count($twigDataCollector->getArguments()) === 1) {
             // In versions of Symfony prior to 3.4, "data_collector.twig" had only one
             // argument, we're adding "twig" service to satisfy constructor overriden
             // in EzSystems\EzPlatformDesignEngineBundle\DataCollector\TwigDataCollector

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,6 @@
             "email": "dev-team@ez.no"
         }
     ],
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "ezsystems/ezpublish-kernel": "^8.0@dev",
         "twig/twig": "^2.11",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.1",
-        "friendsofphp/php-cs-fixer": "^2.15",
+        "friendsofphp/php-cs-fixer": "~2.15.3",
         "mikey179/vfsstream": "^1.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "ezsystems/ezpublish-kernel": "^8.0@dev",
         "twig/twig": "^2.11",
         "symfony/dependency-injection": "^4.3",

--- a/lib/Asset/ProvisionedPathResolver.php
+++ b/lib/Asset/ProvisionedPathResolver.php
@@ -87,7 +87,7 @@ class ProvisionedPathResolver implements AssetPathResolverInterface, AssetPathPr
         $logicalPaths = [];
         /** @var \SplFileInfo $fileInfo */
         foreach ((new Finder())->files()->in($themePath)->exclude('themes')->followLinks()->ignoreUnreadableDirs() as $fileInfo) {
-            $logicalPaths[] = trim(substr($fileInfo->getPathname(), strlen($themePath)), '/');
+            $logicalPaths[] = trim(substr($fileInfo->getPathname(), \strlen($themePath)), '/');
         }
 
         return $logicalPaths;

--- a/lib/Templating/TemplatePathRegistry.php
+++ b/lib/Templating/TemplatePathRegistry.php
@@ -27,7 +27,7 @@ class TemplatePathRegistry implements TemplatePathRegistryInterface, Serializabl
 
     public function mapTemplatePath($templateName, $path)
     {
-        $this->pathMap[$templateName] = str_replace(dirname($this->kernelRootDir) . '/', '', $path);
+        $this->pathMap[$templateName] = str_replace(\dirname($this->kernelRootDir) . '/', '', $path);
     }
 
     public function getTemplatePath($templateName)

--- a/tests/lib/Asset/AssetPathResolverTest.php
+++ b/tests/lib/Asset/AssetPathResolverTest.php
@@ -10,6 +10,7 @@
 namespace EzSystems\EzPlatformDesignEngine\Tests\Asset;
 
 use EzSystems\EzPlatformDesignEngine\Asset\AssetPathResolver;
+use EzSystems\EzPlatformDesignEngine\Exception\InvalidDesignException;
 use PHPUnit\Framework\TestCase;
 use org\bovigo\vfs\vfsStream;
 use Psr\Log\LoggerInterface;
@@ -29,12 +30,13 @@ class AssetPathResolverTest extends TestCase
     }
 
     /**
-     * @expectedException \EzSystems\EzPlatformDesignEngine\Exception\InvalidDesignException
+     * @covers \EzSystems\EzPlatformDesignEngine\Asset\AssetPathResolver::resolveAssetPath
      */
     public function testResolveInvalidDesign()
     {
         $resolver = new AssetPathResolver([], __DIR__);
         $assetPath = 'images/foo.png';
+        $this->expectException(InvalidDesignException::class);
         self::assertSame($assetPath, $resolver->resolveAssetPath($assetPath, 'foo'));
     }
 

--- a/tests/lib/Asset/AssetPathResolverTest.php
+++ b/tests/lib/Asset/AssetPathResolverTest.php
@@ -111,7 +111,7 @@ class AssetPathResolverTest extends TestCase
     {
         $webrootDir = vfsStream::setup('web');
         foreach ($designPaths['foo'] as $designPath) {
-            if (in_array($designPath, $existingPaths)) {
+            if (\in_array($designPath, $existingPaths)) {
                 $fileInfo = new \SplFileInfo($designPath . '/' . $path);
                 $parent = $webrootDir;
                 foreach (explode('/', $fileInfo->getPath()) as $dir) {

--- a/tests/lib/Templating/TemplatePathRegistryTest.php
+++ b/tests/lib/Templating/TemplatePathRegistryTest.php
@@ -16,7 +16,7 @@ class TemplatePathRegistryTest extends TestCase
 {
     private function getExpectedRelativePath($templateFullPath, $kernelRootDir)
     {
-        return str_replace(dirname($kernelRootDir) . '/', '', $templateFullPath);
+        return str_replace(\dirname($kernelRootDir) . '/', '', $templateFullPath);
     }
 
     public function testMapTemplatePath()


### PR DESCRIPTION
- [x] Wait for Travis.
- [ ] Perform fast-forward merge.
- [x] Adjust php-cs-fixer config for v2.15.3 and apply native invocations rules to the package code.
- [x] Use PHP 7.3 for testing on Travis.
- [x] Resolve minimum stability issues and add ezsystems/doctrine-dbal-schema as dependency due to those issues.
- [x] Add `.phpunit.result.cache` to `.gitignore`
- [x] Replace deprecated `@expectedException` annotation with `TestCase::expectException` method call.