### PR TITLE
Aligned package codebase with eZ Platform v2.5 requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+| Question                                  | Answer
+| ---------------------------------------- | ------------------
+| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
+| **Type**                                   | feature/bug/improvement
+| **Target eZ Platform version** | `v2.5`+
+| **BC breaks**                          | yes/no
+
+<!-- Replace this comment with Pull Request description -->
+
+#### Checklist:
+- [ ] Provided PR description.
+- [ ] Tested the solution manually.
+- [ ] Provided automated test coverage.
+- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
+- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
+- [ ] Asked for a review (ping `@ibexa/engineering`).

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache:
 
 matrix:
     include:
-        - php: 5.6
-        - php: 7.0
         - php: 7.1
           env: FIX_CS=true
 

--- a/bundle/DependencyInjection/Compiler/AssetThemePass.php
+++ b/bundle/DependencyInjection/Compiler/AssetThemePass.php
@@ -31,7 +31,7 @@ class AssetThemePass implements CompilerPassInterface
         // Look for assets themes in bundles.
         foreach ($container->getParameter('kernel.bundles') as $bundleName => $bundleClass) {
             $bundleReflection = new \ReflectionClass($bundleClass);
-            $bundleViewsDir = dirname($bundleReflection->getFileName()) . '/Resources/public';
+            $bundleViewsDir = \dirname($bundleReflection->getFileName()) . '/Resources/public';
             $themeDir = $bundleViewsDir . '/themes';
             if (!is_dir($themeDir)) {
                 continue;

--- a/bundle/DependencyInjection/Compiler/PHPStormPass.php
+++ b/bundle/DependencyInjection/Compiler/PHPStormPass.php
@@ -45,7 +45,7 @@ class PHPStormPass implements CompilerPassInterface
 
         (new Filesystem())->dumpFile(
             $twigConfigPath . '/ide-twig.json',
-            json_encode(['namespaces' => $pathConfig], JSON_UNESCAPED_SLASHES)
+            json_encode(['namespaces' => $pathConfig], \JSON_UNESCAPED_SLASHES)
         );
     }
 

--- a/bundle/DependencyInjection/Compiler/TwigThemePass.php
+++ b/bundle/DependencyInjection/Compiler/TwigThemePass.php
@@ -41,7 +41,7 @@ class TwigThemePass implements CompilerPassInterface
         // Look for themes in bundles.
         foreach ($container->getParameter('kernel.bundles') as $bundleName => $bundleClass) {
             $bundleReflection = new ReflectionClass($bundleClass);
-            $bundleViewsDir = dirname($bundleReflection->getFileName()) . '/Resources/views';
+            $bundleViewsDir = \dirname($bundleReflection->getFileName()) . '/Resources/views';
             $themeDir = $bundleViewsDir . '/themes';
             if (!is_dir($themeDir)) {
                 continue;
@@ -99,7 +99,7 @@ class TwigThemePass implements CompilerPassInterface
         $twigDataCollector = $container->findDefinition('data_collector.twig');
         $twigDataCollector->setClass(TwigDataCollector::class);
 
-        if (count($twigDataCollector->getArguments()) === 1) {
+        if (\count($twigDataCollector->getArguments()) === 1) {
             // In versions of Symfony prior to 3.4, "data_collector.twig" had only one
             // argument, we're adding "twig" service to satisfy constructor overriden
             // in EzSystems\EzPlatformDesignEngineBundle\DataCollector\TwigDataCollector

--- a/bundle/DependencyInjection/EzPlatformDesignEngineExtension.php
+++ b/bundle/DependencyInjection/EzPlatformDesignEngineExtension.php
@@ -10,10 +10,10 @@
 namespace EzSystems\EzPlatformDesignEngineBundle\DependencyInjection;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationProcessor;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class EzPlatformDesignEngineExtension extends Extension
 {

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,15 @@
             "email": "jerome@vieilledent.fr"
         },
         {
-            "name": "eZ Systems dev team",
-            "email": "dev-team@ez.no"
+            "name": "Ibexa AS dev team",
+            "homepage": "https://ibexa.co"
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.0.0|^7.0",
-        "twig/twig": "^1.27|^2.0",
-        "symfony/symfony": "^2.8.25|^3.1.6|^3.2.12|^3.3.5"
+        "php": "^7.1",
+        "ezsystems/ezpublish-kernel": "^7.5@dev",
+        "twig/twig": "^2.13.1",
+        "symfony/symfony": "^3.4.47"
     },
     "require-dev": {
         "ezsystems/ezplatform-code-style": "^0.4.0",

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "symfony/symfony": "^2.8.25|^3.1.6|^3.2.12|^3.3.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.0",
-        "friendsofphp/php-cs-fixer": "~2.7.1",
-        "mikey179/vfsstream": "^1.6.3"
+        "ezsystems/ezplatform-code-style": "^0.4.0",
+        "mikey179/vfsstream": "^1.6.3",
+        "phpunit/phpunit": "^5.7|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",
         "friendsofphp/php-cs-fixer": "~2.7.1",
-        "mikey179/vfsStream": "^1.6.3"
+        "mikey179/vfsstream": "^1.6.3"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Asset/AssetPathProvisionerInterface.php
+++ b/lib/Asset/AssetPathProvisionerInterface.php
@@ -16,7 +16,6 @@ interface AssetPathProvisionerInterface
      * Returns an map with asset logical path as key and its resolved path (relative to webroot dir) as value.
      * Example => ['images/foo.png' => 'asset/themes/some_theme/images/foo.png'].
      *
-     * @param array  $assetsPaths
      * @param string $design
      *
      * @return array

--- a/lib/Asset/ProvisionedPathResolver.php
+++ b/lib/Asset/ProvisionedPathResolver.php
@@ -87,7 +87,7 @@ class ProvisionedPathResolver implements AssetPathResolverInterface, AssetPathPr
         $logicalPaths = [];
         /** @var \SplFileInfo $fileInfo */
         foreach ((new Finder())->files()->in($themePath)->exclude('themes')->followLinks()->ignoreUnreadableDirs() as $fileInfo) {
-            $logicalPaths[] = trim(substr($fileInfo->getPathname(), strlen($themePath)), '/');
+            $logicalPaths[] = trim(substr($fileInfo->getPathname(), \strlen($themePath)), '/');
         }
 
         return $logicalPaths;

--- a/lib/Templating/TemplatePathRegistry.php
+++ b/lib/Templating/TemplatePathRegistry.php
@@ -27,7 +27,7 @@ class TemplatePathRegistry implements TemplatePathRegistryInterface, Serializabl
 
     public function mapTemplatePath($templateName, $path)
     {
-        $this->pathMap[$templateName] = str_replace(dirname($this->kernelRootDir) . '/', '', $path);
+        $this->pathMap[$templateName] = str_replace(\dirname($this->kernelRootDir) . '/', '', $path);
     }
 
     public function getTemplatePath($templateName)

--- a/tests/lib/Asset/AssetPathResolverTest.php
+++ b/tests/lib/Asset/AssetPathResolverTest.php
@@ -10,8 +10,8 @@
 namespace EzSystems\EzPlatformDesignEngine\Tests\Asset;
 
 use EzSystems\EzPlatformDesignEngine\Asset\AssetPathResolver;
-use PHPUnit\Framework\TestCase;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class AssetPathResolverTest extends TestCase
@@ -111,7 +111,7 @@ class AssetPathResolverTest extends TestCase
     {
         $webrootDir = vfsStream::setup('web');
         foreach ($designPaths['foo'] as $designPath) {
-            if (in_array($designPath, $existingPaths)) {
+            if (\in_array($designPath, $existingPaths)) {
                 $fileInfo = new \SplFileInfo($designPath . '/' . $path);
                 $parent = $webrootDir;
                 foreach (explode('/', $fileInfo->getPath()) as $dir) {

--- a/tests/lib/Templating/TemplatePathRegistryTest.php
+++ b/tests/lib/Templating/TemplatePathRegistryTest.php
@@ -16,7 +16,7 @@ class TemplatePathRegistryTest extends TestCase
 {
     private function getExpectedRelativePath($templateFullPath, $kernelRootDir)
     {
-        return str_replace(dirname($kernelRootDir) . '/', '', $templateFullPath);
+        return str_replace(\dirname($kernelRootDir) . '/', '', $templateFullPath);
     }
 
     public function testMapTemplatePath()

--- a/tests/lib/Templating/ThemeTemplateNameResolverTest.php
+++ b/tests/lib/Templating/ThemeTemplateNameResolverTest.php
@@ -20,7 +20,7 @@ class ThemeTemplateNameResolverTest extends TestCase
      */
     private $configResolver;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`+
| **BC breaks**                          | yes

Looks like we have misaligned Composer & CS configuration for eZ Platform Design Engine. Branch 2.0 was meant to support eZ Platform v2.x only, Symfony 3.4+, and Twig 2.0.

Branch 2.0 is not tested during nightly builds, so the issues were not visible.

#### TODO
- [ ] Fix PR template on merge up

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review