### PR TITLE
IBX-1431: Set ezdesign.phpstorm.enabled to false on Platform.sh/Ibexa Cloud

### DIFF
--- a/bundle/DependencyInjection/EzPlatformDesignEngineExtension.php
+++ b/bundle/DependencyInjection/EzPlatformDesignEngineExtension.php
@@ -49,8 +49,9 @@ class EzPlatformDesignEngineExtension extends Extension
         $container->setParameter('ezdesign.templates_path_map', $config['templates_theme_paths']);
         $container->setParameter('ezdesign.asset_resolution.disabled', $config['disable_assets_pre_resolution']);
 
-        // PHPStorm settings
-        $container->setParameter('ezdesign.phpstorm.enabled', $config['phpstorm']['enabled']);
+        // PHPStorm settings, it should be disabled on Platform.sh
+        $isPhpStormEnable = isset($_SERVER['PLATFORM_PROJECT_ENTROPY']) ? false : $config['phpstorm']['enabled'];
+        $container->setParameter('ezdesign.phpstorm.enabled', $isPhpStormEnable);
         $container->setParameter('ezdesign.phpstorm.twig_config_path', $config['phpstorm']['twig_config_path']);
     }
 }


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-1431:

Right now it is impossible to get Symfony env variables on the Platform.sh/Ibexa cloud:
```
APP_DEBUG=1 php bin/console debug:container --env-vars

In Filesystem.php line 654:
Unable to write to the "/app" directory.
```
It happens because `ezdesign.phpstorm.enabled` parameter value is `true` despite the fact that it should be `false` for Platform.sh:

1.  There are two packages that are manipulating `ezdesign.phpstorm.enabled`: `EzPlatformCoreExtension` and `EzPlatformDesignEngineExtension`. And `EzPlatformCoreExtension` is processed first.
2. https://github.com/ezsystems/ezplatform-core/blob/master/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php#L176-L179 sets `ezdesign.phpstorm.enabled` to `false`.
3. https://github.com/ezsystems/ezplatform-design-engine/blob/master/bundle/DependencyInjection/EzPlatformDesignEngineExtension.php#L54 always updates `ezdesign.phpstorm.enabled` to `%kernel.debug%` that is default value.

Thats why `ezdesign.phpstorm.enabled` value is always `%kernel.debug%`, even on Platform.sh/Ibexa Cloud.