### PR TITLE
[Composer] Changed mikey179/vfsstream to lowercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",
         "friendsofphp/php-cs-fixer": "~2.7.1",
-        "mikey179/vfsStream": "^1.6.3"
+        "mikey179/vfsstream": "^1.6.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As in https://github.com/ezsystems/BehatBundle/blob/7.0/composer.json#L24

```
require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead.
Reading composer.json of ezsystems/ezplatform-design-engine (v2.0.2)
```