### PR TITLE
IBX-2469: Fixed Serializable deprecation warning on PHP 8.1

### DIFF
--- a/lib/Templating/TemplatePathRegistry.php
+++ b/lib/Templating/TemplatePathRegistry.php
@@ -46,4 +46,14 @@ class TemplatePathRegistry implements TemplatePathRegistryInterface, Serializabl
     {
         list($this->pathMap, $this->kernelRootDir) = unserialize($serialized);
     }
+
+    public function __serialize(): array
+    {
+        return [$this->pathMap, $this->kernelRootDir];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        list($this->pathMap, $this->kernelRootDir) = $data;
+    }
 }

--- a/lib/Templating/TemplatePathRegistry.php
+++ b/lib/Templating/TemplatePathRegistry.php
@@ -10,11 +10,10 @@ use Serializable;
 
 class TemplatePathRegistry implements TemplatePathRegistryInterface, Serializable
 {
+    /** @var array<string, string> */
     private $pathMap = [];
 
-    /**
-     * @var
-     */
+    /** @var string */
     private $kernelRootDir;
 
     public function __construct($kernelRootDir)
@@ -44,7 +43,7 @@ class TemplatePathRegistry implements TemplatePathRegistryInterface, Serializabl
 
     public function unserialize($serialized)
     {
-        list($this->pathMap, $this->kernelRootDir) = unserialize($serialized);
+        [$this->pathMap, $this->kernelRootDir] = unserialize($serialized);
     }
 
     public function __serialize(): array
@@ -54,6 +53,6 @@ class TemplatePathRegistry implements TemplatePathRegistryInterface, Serializabl
 
     public function __unserialize(array $data): void
     {
-        list($this->pathMap, $this->kernelRootDir) = $data;
+        [$this->pathMap, $this->kernelRootDir] = $data;
     }
 }


### PR DESCRIPTION
> JIRA: https://issues.ibexa.co/browse/IBX-2469

### Description

Fixed the following deprecation warning on PHP 8.1:

```
PHP Deprecated:  EzSystems\EzPlatformDesignEngine\Templating\TemplatePathRegistry implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /var/www/vendor/ezsystems/ezplatform-design-engine/lib/Templating/TemplatePathRegistry.php on line 11
```