### PR TITLE
Dropped creating global templates directory via compiler pass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '8.0'
+                    - '8.1'
         steps:
             - uses: actions/checkout@v2
 

--- a/bundle/DependencyInjection/Compiler/AssetThemePass.php
+++ b/bundle/DependencyInjection/Compiler/AssetThemePass.php
@@ -75,8 +75,11 @@ class AssetThemePass implements CompilerPassInterface
         }
 
         $themesList = $container->getParameter('ezdesign.themes_list');
-        $container->setParameter('ezdesign.themes_list', array_unique(
-            array_merge($themesList, array_keys($themesPathMap)))
+        $container->setParameter(
+            'ezdesign.themes_list',
+            array_unique(
+                array_merge($themesList, array_keys($themesPathMap))
+            )
         );
         $container->setParameter('ezdesign.assets_path_map', $pathsByDesign);
         $container->findDefinition('ezdesign.asset_path_resolver')

--- a/bundle/DependencyInjection/Compiler/TwigThemePass.php
+++ b/bundle/DependencyInjection/Compiler/TwigThemePass.php
@@ -88,8 +88,11 @@ class TwigThemePass implements CompilerPassInterface
         }
 
         $themesList = $container->getParameter('ezdesign.themes_list');
-        $container->setParameter('ezdesign.themes_list', array_unique(
-            array_merge($themesList, array_keys($themesPathMap)))
+        $container->setParameter(
+            'ezdesign.themes_list',
+            array_unique(
+            array_merge($themesList, array_keys($themesPathMap))
+        )
         );
         $container->setParameter('ezdesign.templates_path_map', $themesPathMap);
 

--- a/composer.json
+++ b/composer.json
@@ -58,8 +58,6 @@
         "lolautruche/ez-core-extra-bundle": "<2.0"
     },
     "config": {
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true
-        }
+        "allow-plugins": false
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,8 @@
     },
     "require-dev": {
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
-        "ezsystems/ezplatform-code-style": "^1.0",
+        "ibexa/code-style": "^1.0",
         "phpunit/phpunit": "^8.1",
-        "friendsofphp/php-cs-fixer": "^2.16.0",
         "mikey179/vfsstream": "^1.6"
     },
     "autoload": {

--- a/lib/Templating/TemplateNameResolverInterface.php
+++ b/lib/Templating/TemplateNameResolverInterface.php
@@ -12,7 +12,7 @@ namespace EzSystems\EzPlatformDesignEngine\Templating;
  */
 interface TemplateNameResolverInterface
 {
-    const EZ_DESIGN_NAMESPACE = 'ezdesign';
+    public const EZ_DESIGN_NAMESPACE = 'ezdesign';
 
     /**
      * Resolves provided template name within current design and returns properly namespaced template name.


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | n/a |
| **Type**                 | improvement                             |
| **Target Ibexa version** | `v3.3`+              |
| **BC breaks**            | no                                              |
| **Regression tests** | https://github.com/ibexa/commerce/pull/641

TwigThemePass for no reason tries to create global templates directory if it doesn't exist. This operation is not necessary because for themes directories to be collected, they need to exist as well. Moreover it's redundant as recipes create global templates directory.

Discovered by accident while trying to investigate the root cause of `%kernel.project_dir%/templates` being created while running integration tests. This PR resolves that.

To be able to create this PR I needed to refresh code style package as it was running a version which wasn't supported on PHP8.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.